### PR TITLE
Add registration validation and more activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Practice and compete in basketball tournaments",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore various art techniques and create projects",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Participate in plays and improve acting skills",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+    },
+    "Math Club": {
+        "description": "Solve challenging math problems and prepare for competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
     }
 }
 
@@ -62,6 +98,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specificy activity
     activity = activities[activity_name]
 
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -25,6 +25,14 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <h5>Participants:</h5>
+          <ul>
+            ${
+              details.participants.length > 0
+                ? details.participants.map((participant) => `<li>${participant}</li>`).join("")
+                : "<li>No participants yet</li>"
+            }
+          </ul>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -26,7 +26,7 @@ document.addEventListener("DOMContentLoaded", () => {
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
           <h5>Participants:</h5>
-          <ul>
+          <ul class="participant-list">
             ${
               details.participants.length > 0
                 ? details.participants.map((participant) => `<li>${participant}</li>`).join("")

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,18 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.activity-card ul {
+  margin-top: 10px;
+  padding-left: 20px;
+  list-style-type: disc;
+  color: #333;
+}
+
+.activity-card ul li {
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -76,14 +76,21 @@ section h3 {
 
 .activity-card ul {
   margin-top: 10px;
-  padding-left: 20px;
+  margin-left: 0; /* Remove default margin */
+  padding-left: 20px; /* Ensure bullets are indented within the box */
   list-style-type: disc;
+  list-style-position: inside; /* Ensure bullets are inside the shaded box */
   color: #333;
+  background-color: #f1f1f1;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  padding: 10px;
 }
 
 .activity-card ul li {
   margin-bottom: 5px;
   font-size: 14px;
+  color: #555;
 }
 
 .form-group {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -1,3 +1,4 @@
+/* General Reset */
 * {
   box-sizing: border-box;
   margin: 0;
@@ -5,6 +6,7 @@
   font-family: Arial, sans-serif;
 }
 
+/* Body Styles */
 body {
   font-family: Arial, sans-serif;
   line-height: 1.6;
@@ -15,6 +17,7 @@ body {
   background-color: #f5f5f5;
 }
 
+/* Header Styles */
 header {
   text-align: center;
   padding: 20px 0;
@@ -28,6 +31,7 @@ header h1 {
   margin-bottom: 10px;
 }
 
+/* Main Layout */
 main {
   display: flex;
   flex-wrap: wrap;
@@ -41,6 +45,7 @@ main {
   }
 }
 
+/* Section Styles */
 section {
   background-color: white;
   padding: 20px;
@@ -57,6 +62,7 @@ section h3 {
   color: #1a237e;
 }
 
+/* Activity Card Styles */
 .activity-card {
   margin-bottom: 15px;
   padding: 15px;
@@ -74,25 +80,27 @@ section h3 {
   margin-bottom: 8px;
 }
 
-.activity-card ul {
+/* Participant Section Styles */
+.participant-list {
   margin-top: 10px;
   margin-left: 0; /* Remove default margin */
   padding-left: 20px; /* Ensure bullets are indented within the box */
   list-style-type: disc;
   list-style-position: inside; /* Ensure bullets are inside the shaded box */
   color: #333;
-  background-color: #f1f1f1;
+  background-color: #f1f1f1; /* Gray background only for the participant list */
   border: 1px solid #ddd;
   border-radius: 5px;
   padding: 10px;
 }
 
-.activity-card ul li {
+.participant-list li {
   margin-bottom: 5px;
   font-size: 14px;
   color: #555;
 }
 
+/* Form Styles */
 .form-group {
   margin-bottom: 15px;
 }
@@ -112,6 +120,7 @@ section h3 {
   font-size: 16px;
 }
 
+/* Button Styles */
 button {
   background-color: #1a237e;
   color: white;
@@ -127,6 +136,7 @@ button:hover {
   background-color: #3949ab;
 }
 
+/* Message Styles */
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -155,6 +165,7 @@ button:hover {
   display: none;
 }
 
+/* Footer Styles */
 footer {
   text-align: center;
   margin-top: 30px;


### PR DESCRIPTION
This pull request introduces several enhancements to the activities management system, including the addition of new activities, improved validation for signups, updates to the user interface to display participants, and extensive styling improvements.

### Backend Changes:
* Added six new activities (`Soccer Team`, `Basketball Team`, `Art Club`, `Drama Club`, `Math Club`, and `Science Club`) to the `activities` dictionary, each with a description, schedule, maximum participants, and initial participants. (`src/app.py`, [src/app.pyR41-R76](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R41-R76))
* Updated the `signup_for_activity` function to validate that a student is not already signed up for an activity before adding them, throwing an error if they are. (`src/app.py`, [src/app.pyR101-R104](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R101-R104))

### Frontend Changes:
* Enhanced the activity cards in the UI to display a list of participants for each activity. If no participants are present, a placeholder message is shown. (`src/static/app.js`, [src/static/app.jsR28-R35](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28-R35))

### Styling Improvements:
* Introduced new styles for participant lists, including a gray background, border, padding, and bullet points inside the box. (`src/static/styles.css`, [src/static/styles.cssR83-R103](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R83-R103))
* Added structured styles for various sections, including general resets, headers, main layout, activity cards, and buttons, improving the overall design consistency. (`src/static/styles.css`, [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R1-R9) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R20) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R34) [[4]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R48) [[5]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R65) [[6]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R123) [[7]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R139) [[8]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R168)